### PR TITLE
Fix GitHubAPI and IssueGenerator

### DIFF
--- a/app/services/github_api.rb
+++ b/app/services/github_api.rb
@@ -1,14 +1,16 @@
 # frozen_string_literal: true
 
 class GithubApi
-  SEARCH_QUERY = %(
+  SEARCH_QUERY = <<~QUERY.squish
     language:ruby
-    is:issue state:open
+    is:issue
+    state:open
     label:good-first-issue,"Good First Issue",beginner,beginner-friendly
     sort:created
-  )
+  QUERY
+
   def initialize
-    @client = Octokit::Client.new(access_token: ENV.fetch['GITHUB_ACCESS_TOKEN'], per_page: 100)
+    @client = Octokit::Client.new(access_token: ENV.fetch("GITHUB_ACCESS_TOKEN"), per_page: 100)
   end
 
   def search_issues

--- a/app/services/issue_generator.rb
+++ b/app/services/issue_generator.rb
@@ -43,7 +43,7 @@ class IssueGenerator
   end
 
   def create_tags(issue)
-    tag_names = issue.labels.pluck(:name)
+    tag_names = issue.tags.pluck(:name)
     tag_names.each do |tag_name|
       tag = Tag.find_or_create_by(name: tag_name)
       IssueTag.create(issue:, tag:)


### PR DESCRIPTION
While looking into the app today I saw that Issue.find_issues was no longer working because of some issues in the GithubApi and IssueGenerator files, so I fixed it. There will probably be further changes to do to improve how we find and create issues but for now this allows us to generate a bunch of issues without any obvious errors happening.