### PR TITLE
Move issue generator into a job

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@
 /tmp/*
 !/log/.keep
 !/tmp/.keep
+dump.rdb
 
 # Ignore pidfiles, but keep the directory.
 /tmp/pids/*

--- a/Gemfile
+++ b/Gemfile
@@ -31,6 +31,9 @@ gem 'simple_form' # Form helper that generates forms with Bootstrap classes
 gem 'devise' # Authentication
 gem 'octokit', '~> 5.0' # Wrapper for the GitHub API
 gem 'pg_search'
+gem 'sidekiq'
+gem 'sidekiq-failures'
+
 # Development and Testing Tools
 group :development, :test do
   gem 'debug', platforms: %i[mri mingw x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -91,6 +91,7 @@ GEM
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
     concurrent-ruby (1.2.2)
+    connection_pool (2.4.1)
     crass (1.0.6)
     date (3.3.3)
     debug (1.8.0)
@@ -226,6 +227,8 @@ GEM
       zeitwerk (~> 2.5)
     rainbow (3.1.1)
     rake (13.0.6)
+    redis-client (0.17.1)
+      connection_pool
     regexp_parser (2.8.1)
     reline (0.3.7)
       io-console (~> 0.5)
@@ -276,6 +279,13 @@ GEM
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2, < 3.0)
       websocket (~> 1.0)
+    sidekiq (7.1.6)
+      concurrent-ruby (< 2)
+      connection_pool (>= 2.3.0)
+      rack (>= 2.2.4)
+      redis-client (>= 0.14.0)
+    sidekiq-failures (1.0.4)
+      sidekiq (>= 4.0.0)
     simple_form (5.2.0)
       actionpack (>= 5.2)
       activemodel (>= 5.2)
@@ -346,6 +356,8 @@ DEPENDENCIES
   rubocop-rake
   sassc-rails
   selenium-webdriver
+  sidekiq
+  sidekiq-failures
   simple_form
   sprockets-rails
   stimulus-rails

--- a/app/models/issue.rb
+++ b/app/models/issue.rb
@@ -29,16 +29,4 @@ class Issue < ApplicationRecord
   enum status: %i[open closed]
 
   pg_search_scope :search_by_keyword, against: %i[title description repo_name]
-
-  def self.find_issues
-    issues = GithubApi.new.search_issues.items
-    active_issues = []
-    issues.each do |issue|
-      i = IssueGenerator.new(issue).create
-      active_issues << i
-    end
-
-    issues_no_longer_available = Issue.where(category: 'open-source') - active_issues
-    issues_no_longer_available.each(&:closed!)
-  end
 end

--- a/app/sidekiq/create_issues_job.rb
+++ b/app/sidekiq/create_issues_job.rb
@@ -1,0 +1,8 @@
+class CreateIssuesJob
+  include Sidekiq::Job
+
+  def perform
+    issues = GithubApi.new.search_issues.items
+    issues.each { |issue| IssueGenerator.new(issue).create }
+  end
+end

--- a/config/application.rb
+++ b/config/application.rb
@@ -20,5 +20,6 @@ module FirstContributions
     #
     # config.time_zone = "Central Time (US & Canada)"
     # config.eager_load_paths << Rails.root.join("extras")
+    config.active_job.queue_adapter = :sidekiq
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,9 +1,23 @@
 # frozen_string_literal: true
 
+require "sidekiq/web"
+
 Rails.application.routes.draw do
   devise_for :users do
     get '/users/sign_out' => 'devise/sessions#destroy'
   end
+
+  Sidekiq::Web.use Rack::Auth::Basic do |username, password|
+    # Protect against timing attacks:
+    # - See https://codahale.com/a-lesson-in-timing-attacks/
+    # - See https://thisdata.com/blog/timing-attacks-against-string-comparison/
+    # - Use & (do not use &&) so that it doesn't short circuit.
+    # - Use digests to stop length information leaking (see also ActiveSupport::SecurityUtils.variable_size_secure_compare)
+    ActiveSupport::SecurityUtils.secure_compare(::Digest::SHA256.hexdigest(username), ::Digest::SHA256.hexdigest(ENV["SIDEKIQ_USERNAME"])) &
+      ActiveSupport::SecurityUtils.secure_compare(::Digest::SHA256.hexdigest(password), ::Digest::SHA256.hexdigest(ENV["SIDEKIQ_PASSWORD"]))
+  end if Rails.env.production?
+  mount Sidekiq::Web, at: "/sidekiq"
+
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 
   # Defines the root path route ("/")


### PR DESCRIPTION
This PR sets up Sidekiq (https://github.com/Contributees/First-Ruby-Quest/issues/5) and moves the logic we had to make the API call and create Issues from the Issue model to a Sidekiq job.

This job will only be used to get new issues. We will create another job to update the information of pre-existing issues in a future PR.

I added a piece of code to require a username and password when trying to access the Sidekiq dashboard in production. I'll try it out when this is merged and I've deployed. I'll also see if I can schedule this job with Heroku scheduler once I've deployed.