### PR TITLE
Fix li elements

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -36,7 +36,10 @@ p {
   font-weight: 300;
   font-size: 1rem;
 }
-h2, h3, h4 {
+
+h2,
+h3,
+h4 {
   font-family: $sub-headers-font;
   font-weight: 400;
 }

--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -2,12 +2,9 @@
 @tailwind components;
 @tailwind utilities;
 
-/*
-
-@layer components {
-  .btn-primary {
-    @apply py-2 px-4 bg-blue-200;
+@layer base {
+  ul,
+  ol {
+    list-style: revert;
   }
 }
-
-*/


### PR DESCRIPTION
## What does this PR do?

The default list style for Tailwind is list-style-type: none. This is why we couldn't see bullet points or numbers when using li elements in unordered or ordered lists. So I have reverted this as per the answer of this StackOverflow question:
https://stackoverflow.com/questions/69276276/why-tailwind-list-style-type-is-not-working

I just realised I had also committed app/assets/stylesheets/application.scss. The change was made automatically by my linter, it is not linked to lists in any way in case you're wondering.

## Screenshot
![Screenshot 2024-02-12 161009](https://github.com/Contributees/First-Ruby-Quest/assets/99920845/35a16b3e-2918-445d-9ffd-f368a2d9f05b)

## Related issue
https://github.com/Contributees/First-Ruby-Quest/issues/14

## References
This is the base style for Preflight:
https://tailwindcss.com/docs/preflight#lists-are-unstyled

And these are the possible classes for list style types in Tailwind: https://tailwindcss.com/docs/list-style-type