### PR TITLE
Fix blockquotes and code blocks

### DIFF
--- a/app/assets/stylesheets/actiontext.scss
+++ b/app/assets/stylesheets/actiontext.scss
@@ -47,4 +47,16 @@ trix-editor {
     margin-left: 0.3em;
     padding-left: 0.6em;
   }
+
+  pre {
+    display: inline-block;
+    width: 100%;
+    vertical-align: top;
+    font-family: monospace;
+    font-size: 1em;
+    padding: 0.5em;
+    white-space: pre;
+    background-color: #eee;
+    overflow-x: auto;
+  }
 }

--- a/app/assets/stylesheets/actiontext.scss
+++ b/app/assets/stylesheets/actiontext.scss
@@ -18,8 +18,13 @@
   max-width: 33%;
 }
 
-.trix-content .attachment-gallery.attachment-gallery--2 > action-text-attachment,
-.trix-content .attachment-gallery.attachment-gallery--2 > .attachment, .trix-content .attachment-gallery.attachment-gallery--4 > action-text-attachment,
+.trix-content
+  .attachment-gallery.attachment-gallery--2
+  > action-text-attachment,
+.trix-content .attachment-gallery.attachment-gallery--2 > .attachment,
+.trix-content
+  .attachment-gallery.attachment-gallery--4
+  > action-text-attachment,
 .trix-content .attachment-gallery.attachment-gallery--4 > .attachment {
   flex-basis: 50%;
   max-width: 50%;
@@ -33,5 +38,13 @@
 trix-editor {
   &.customized-min-height {
     min-height: 15em;
+  }
+
+  blockquote {
+    border: 0 solid #ccc;
+    border-left-width: 0px;
+    border-left-width: 0.3em;
+    margin-left: 0.3em;
+    padding-left: 0.6em;
   }
 }

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -36,9 +36,16 @@ p {
   font-weight: 300;
   font-size: 1rem;
 }
-h2, h3, h4 {
+
+h2,
+h3,
+h4 {
   font-family: $sub-headers-font;
   font-weight: 400;
+}
+
+pre {
+  color: $dark-pink;
 }
 
 .text-italic {


### PR DESCRIPTION
## What does this PR do?
It fixes theses issues:

- Blockquote style was not visible in trix-editor
- Code block style was not visible in trix-editor
- Code blocks were not readable in user-created issues because of the lack of contrast (white on white)

See issue https://github.com/Contributees/First-Ruby-Quest/issues/14

## Screenshots after change
Blockquote in trix-editor
![Quotations in trix-editor](https://github.com/Contributees/First-Ruby-Quest/assets/99920845/85df8ba6-ea7d-429c-8562-48d2ac319fa2)

Code block in trix-editor
![Code block in trix-editor](https://github.com/Contributees/First-Ruby-Quest/assets/99920845/9a3b97e6-fed2-4667-8d24-3ea13a2d8600)

Code block in user-created issue
![Code block in created issue](https://github.com/Contributees/First-Ruby-Quest/assets/99920845/84e5b215-335b-447c-8d00-dbed3b7d9247)
